### PR TITLE
adding define for FETT263_FORCE_PUSH_LENGTH (#121)

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -123,6 +123,10 @@
 // To enable gesture controlled Force Push full time
 // (will use push.wav or force.wav if not present)
 //
+// FETT263_FORCE_PUSH_LENGTH 5
+// Allows for adjustment to Push gesture length in millis needed to trigger Force Push
+// Recommended range 1 ~ 10, 1 = shortest, easiest to trigger, 10 = longest
+//
 // FETT263_MULTI_PHASE
 // This will enable a preset change while ON to create a "Multi-Phase" saber effect
 //
@@ -156,6 +160,10 @@
 
 #ifndef FETT263_LOCKUP_DELAY
 #define FETT263_LOCKUP_DELAY 200
+#endif
+
+#ifndef FETT263_FORCE_PUSH_LENGTH
+#define FETT263_FORCE_PUSH_LENGTH 5
 #endif
 
 #if defined(FETT263_BATTLE_MODE_ALWAYS_ON) && defined(FETT263_BATTLE_MODE_START_ON)
@@ -315,7 +323,7 @@ SaberFett263Buttons() : PropBase() {}
           mss.y * mss.y + mss.z * mss.z > 70 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > 5) {
+        if (millis() - push_begin_millis_ > FETT263_FORCE_PUSH_LENGTH) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
         } 
@@ -798,7 +806,9 @@ SaberFett263Buttons() : PropBase() {}
         // Delay twist events to prevent false trigger from over twisting
         if (millis() - last_twist_ > 2000) {
           last_twist_ = millis();
+          Off();
           next_preset();
+          FastOn();
         }
         return true;
 
@@ -806,7 +816,9 @@ SaberFett263Buttons() : PropBase() {}
         // Delay twist events to prevent false trigger from over twisting
         if (millis() - last_twist_ > 2000) {
           last_twist_ = millis();
+          Off();
           previous_preset();
+          FastOn();
         }
         return true;
 #endif


### PR DESCRIPTION
* Fix for missed clash on swings

fixing Battle Mode clash when swings continue per discussion on TRA

* add define to fine-tune Force Push length

including #define FETT263_FORCE_PUSH_LENGTH to allow users to set push length in millis in config.

* Using FastOn for Multi-Phase preset change

To bypass Preon effects and sounds during the preset change while ON, I've changed the Multi-Phase case to use FastOn()